### PR TITLE
Fix Scalafmt rules

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,12 +1,11 @@
-version=3.0.0
+version = 3.0.0
 align.openParenCallSite = true
 align.openParenDefnSite = true
 maxColumn = 120
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true
-danglingParentheses = true
+danglingParentheses.preset = true
 rewrite.rules = [AvoidInfix, SortImports, RedundantParens, SortModifiers]
-docstrings = JavaDoc
 newlines.afterCurlyLambda = preserve
 docstrings.style = Asterisk
 docstrings.oneline = unfold


### PR DESCRIPTION
Currently, formatting fails because the new version of Scalafmt brings changes in rules. That PR fix it.