### PR TITLE
Set Sonatype Credential Host

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ ThisBuild / publishFullName := "Christopher Davenport"
 
 ThisBuild / spiewakMainBranches := Seq("main", "series/2.x")
 
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+
 enablePlugins(SonatypeCiReleasePlugin)
 
 lazy val unique = project


### PR DESCRIPTION
I manually released v2.2.0 to get around this, but it clears the mine in case there's another patch someday.